### PR TITLE
feat: :sparkles: add simple substitution cipher and update README accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,23 @@ A collection of bad ciphers that should not be used in any serious application, 
 ```typescript
 import * as xor from '@bad-ciphers/xor';
 import * as caesar from '@bad-ciphers/caesar';
+import * as simpleSubstitution from '@bad-ciphers/simple-substitution';
 
 const encoded = xor.encode('Hello World!', 0xffff);
 const decoded = xor.decode(encoded, 0xffff);
 
 const caesar_ed = caesar.encode('Hello World!', 7);
 const uncaesar_ed = caesar.decode(caesar_ed, 7);
+
+const simpleSubstitution_ed = simpleSubstitution.encode('Hello World!', 'zyxwvutsrqponmlkjihgfedcba');
+const unsimpleSubstitution_ed = simpleSubstitution.decode(simpleSubstitution_ed, 'zyxwvutsrqponmlkjihgfedcba');
 ```
 
 ## Ciphers
 
 - [XOR](./packages/xor/README.md)
 - [Caesar](./packages/caesar/README.md)
+- [Simple Substitution](./packages/simple-substitution/README.md)
 
 ## License
 

--- a/packages/simple-substitution/.eslintrc.json
+++ b/packages/simple-substitution/.eslintrc.json
@@ -1,0 +1,30 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "ignoredFiles": ["{projectRoot}/vite.config.{js,ts,mjs,mts}"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/simple-substitution/README.md
+++ b/packages/simple-substitution/README.md
@@ -7,7 +7,7 @@ An implementation of the Simple Substitution Cipher.
 ```js
 import { encode, decode } from '@bad-ciphers/simple-substitution';
 
-const encoded = encode('Hello World', 'veycibjhougdrqnkwflpzsatmx')
+const encoded = encode('Hello World', 'veycibjhougdrqnkwflpzsatmx');
 // encoded === 'Hiddn Anfdc'
 const decoded = decode('Hiddn Anfdc!', 'veycibjhougdrqnkwflpzsatmx');
 // decoded === 'Hello World'

--- a/packages/simple-substitution/README.md
+++ b/packages/simple-substitution/README.md
@@ -1,0 +1,14 @@
+# @bad-ciphers/simple-substitution
+
+An implementation of the Simple Substitution Cipher.
+
+## Usage
+
+```js
+import { encode, decode } from '@bad-ciphers/simple-substitution';
+
+const encoded = encode('Hello World', 'veycibjhougdrqnkwflpzsatmx')
+// encoded === 'Hiddn Anfdc'
+const decoded = decode('Hiddn Anfdc!', 'veycibjhougdrqnkwflpzsatmx');
+// decoded === 'Hello World'
+```

--- a/packages/simple-substitution/package.json
+++ b/packages/simple-substitution/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@bad-ciphers/simple-substitution",
+  "version": "0.1.0",
+  "dependencies": {},
+  "main": "./index.js",
+  "module": "./index.mjs",
+  "typings": "./index.d.ts"
+}

--- a/packages/simple-substitution/project.json
+++ b/packages/simple-substitution/project.json
@@ -1,0 +1,55 @@
+{
+  "name": "simple-substitution",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/simple-substitution/src",
+  "projectType": "library",
+  "targets": {
+    "copyAssets": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["build"],
+      "options": {
+        "args": "--outputPath=dist/packages/simple-substitution",
+        "commands": [
+          "cp -v LICENSE {args.outputPath}",
+          "cp -v {projectRoot}/*.md {args.outputPath}"
+        ]
+      }
+    },
+    "build": {
+      "executor": "@nx/vite:build",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/simple-substitution"
+      }
+    },
+    "publish": {
+      "command": "node tools/scripts/publish.mjs simple-substitution {args.ver} {args.tag}",
+      "dependsOn": ["copyAssets", "build"]
+    },
+    "test": {
+      "executor": "@nx/vite:test",
+      "outputs": ["{options.reportsDirectory}"],
+      "options": {
+        "passWithNoTests": true,
+        "reportsDirectory": "../../coverage/packages/simple-substitution"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "packages/simple-substitution/**/*.ts",
+          "packages/simple-substitution/package.json"
+        ]
+      }
+    },
+    "version": {
+      "executor": "@jscutlery/semver:version",
+      "options": {
+        "preset": "conventional"
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/simple-substitution/src/index.ts
+++ b/packages/simple-substitution/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/simple-substitution';

--- a/packages/simple-substitution/src/lib/simple-substitution.spec.ts
+++ b/packages/simple-substitution/src/lib/simple-substitution.spec.ts
@@ -35,7 +35,11 @@ describe('simpleSubstitution', () => {
     const invalidKey = 'invalid'; // An invalid key that doesn't have 26 unique characters
 
     // Encoding and decoding should throw an error with an invalid key
-    expect(() => encode('hello', invalidKey)).toThrowError('The key must contain 26 unique characters.');
-    expect(() => decode('ifmmp', invalidKey)).toThrowError('The key must contain 26 unique characters.');
+    expect(() => encode('hello', invalidKey)).toThrowError(
+      'The key must contain 26 unique characters.',
+    );
+    expect(() => decode('ifmmp', invalidKey)).toThrowError(
+      'The key must contain 26 unique characters.',
+    );
   });
 });

--- a/packages/simple-substitution/src/lib/simple-substitution.spec.ts
+++ b/packages/simple-substitution/src/lib/simple-substitution.spec.ts
@@ -1,0 +1,41 @@
+import { encode, decode } from './simple-substitution';
+
+describe('simpleSubstitution', () => {
+  const validKey = 'bcdefghijklmnopqrstuvwxyza'; // A valid substitution key
+
+  it('should encode correctly', () => {
+    // Test cases with a valid key
+    expect(encode('hello', validKey)).toBe('ifmmp');
+    expect(encode('HELLO', validKey)).toBe('IFMMP');
+    expect(encode('Hello', validKey)).toBe('Ifmmp');
+
+    // Test cases with non-alphabetical characters
+    expect(encode('Hello, world!', validKey)).toBe('Ifmmp, xpsme!');
+
+    // Test cases with emojis
+    expect(encode('👍👍👍', validKey)).toBe('👍👍👍');
+    expect(encode('Hello 👍', validKey)).toBe('Ifmmp 👍');
+  });
+
+  it('should decode correctly', () => {
+    // Test cases with a valid key
+    expect(decode('ifmmp', validKey)).toBe('hello');
+    expect(decode('IFMMP', validKey)).toBe('HELLO');
+    expect(decode('Ifmmp', validKey)).toBe('Hello');
+
+    // Test cases with non-alphabetical characters
+    expect(decode('Ifmmp, xpsme!', validKey)).toBe('Hello, world!');
+
+    // Test cases with emojis
+    expect(decode('👍👍👍', validKey)).toBe('👍👍👍');
+    expect(decode('Ifmmp 👍', validKey)).toBe('Hello 👍');
+  });
+
+  it('should throw an error for invalid key', () => {
+    const invalidKey = 'invalid'; // An invalid key that doesn't have 26 unique characters
+
+    // Encoding and decoding should throw an error with an invalid key
+    expect(() => encode('hello', invalidKey)).toThrowError('The key must contain 26 unique characters.');
+    expect(() => decode('ifmmp', invalidKey)).toThrowError('The key must contain 26 unique characters.');
+  });
+});

--- a/packages/simple-substitution/src/lib/simple-substitution.ts
+++ b/packages/simple-substitution/src/lib/simple-substitution.ts
@@ -3,19 +3,23 @@ export function encode(input: string, key: string) {
     throw new Error('The key must contain 26 unique characters.');
   }
 
-  const alphabet = 'abcdefghijklmnopqrstuvwxyz';
+  const lowercaseKey = key.toLowerCase();
+  const uppercaseKey = key.toUpperCase();
+  const newKey = lowercaseKey + uppercaseKey;
+
+  const alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
   const substitutionMap: Record<string, string> = {};
 
-  for (let i = 0; i < 26; i++) {
-    substitutionMap[alphabet[i]] = key[i];
+  for (let i = 0; i < 52; i++) {
+    substitutionMap[alphabet[i]] = newKey[i];
   }
 
-  const substitutedString = input
+  const encodedString = input
     .split('')
     .map((char) => (substitutionMap[char] ? substitutionMap[char] : char))
     .join('');
 
-  return substitutedString;
+  return encodedString;
 }
 
 export function decode(input: string, key: string) {
@@ -23,6 +27,21 @@ export function decode(input: string, key: string) {
     throw new Error('The key must contain 26 unique characters.');
   }
 
-  const reverseKey = key.split('').reverse().join('');
-  return encode(input, reverseKey);
+  const lowercaseKey = key.toLowerCase();
+  const uppercaseKey = key.toUpperCase();
+  const newKey = lowercaseKey + uppercaseKey;
+
+  const alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  const substitutionMap: Record<string, string> = {};
+
+  for (let i = 0; i < 52; i++) {
+    substitutionMap[newKey[i]] = alphabet[i];
+  }
+
+  const decodedString = input
+    .split('')
+    .map((char) => (substitutionMap[char] ? substitutionMap[char] : char))
+    .join('');
+
+  return decodedString;
 }

--- a/packages/simple-substitution/src/lib/simple-substitution.ts
+++ b/packages/simple-substitution/src/lib/simple-substitution.ts
@@ -1,0 +1,28 @@
+export function encode(input: string, key: string) {
+  if (key.length !== 26 || new Set(key).size !== 26) {
+    throw new Error('The key must contain 26 unique characters.');
+  }
+
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz';
+  const substitutionMap: Record<string, string> = {};
+
+  for (let i = 0; i < 26; i++) {
+    substitutionMap[alphabet[i]] = key[i];
+  }
+
+  const substitutedString = input
+    .split('')
+    .map((char) => (substitutionMap[char] ? substitutionMap[char] : char))
+    .join('');
+
+  return substitutedString;
+}
+
+export function decode(input: string, key: string) {
+  if (key.length !== 26 || new Set(key).size !== 26) {
+    throw new Error('The key must contain 26 unique characters.');
+  }
+
+  const reverseKey = key.split('').reverse().join('');
+  return encode(input, reverseKey);
+}

--- a/packages/simple-substitution/tsconfig.json
+++ b/packages/simple-substitution/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/simple-substitution/tsconfig.lib.json
+++ b/packages/simple-substitution/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node", "vite/client"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/simple-substitution/tsconfig.spec.json
+++ b/packages/simple-substitution/tsconfig.spec.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "vitest"
+    ]
+  },
+  "include": [
+    "vite.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/packages/simple-substitution/vite.config.ts
+++ b/packages/simple-substitution/vite.config.ts
@@ -1,0 +1,54 @@
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+import * as path from 'path';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+declare module 'vite' {
+  interface UserConfig {
+    test: import('vitest/config').UserConfig['test'];
+  }
+}
+
+export default defineConfig({
+  cacheDir: '../../node_modules/.vite/simple-substitution',
+
+  plugins: [
+    nxViteTsPaths(),
+    dts({
+      entryRoot: 'src',
+      tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+    }),
+  ],
+
+  // Uncomment this if you are using workers.
+  // worker: {
+  //  plugins: [ nxViteTsPaths() ],
+  // },
+
+  // Configuration for building your library.
+  // See: https://vitejs.dev/guide/build.html#library-mode
+  build: {
+    lib: {
+      // Could also be a dictionary or array of multiple entry points.
+      entry: 'src/index.ts',
+      name: 'simple-substitution',
+      fileName: 'index',
+      // Change this to the formats you want to support.
+      // Don't forget to update your package.json as well.
+      formats: ['es', 'cjs'],
+    },
+    rollupOptions: {
+      // External packages that should not be bundled into your library.
+      external: [],
+    },
+  },
+
+  test: {
+    globals: true,
+    cache: {
+      dir: '../../node_modules/.vitest',
+    },
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+  },
+});


### PR DESCRIPTION
Fixes #3 

## Changes made:
- Added `simple-substitution` cipher in the package
- Add all other _chore_ files for the package to work
- Added `simple-substitution.spec.ts` file for testing
- Updated the `README.md` file with the new cipher documentation

## Breaking Changes
No breaking changes